### PR TITLE
RestClient changes to pass back error response from the server

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,23 +1,44 @@
-plugins {
-    id 'net.researchgate.release' version '2.3.4'
-}
-
 group 'com.capgemini'
 
 apply plugin: 'java'
 apply plugin: 'maven'
+apply plugin: 'net.researchgate.release'
+
+buildscript {
+    repositories {
+        mavenLocal()
+        mavenCentral()
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
+        maven {
+            url "http://dl.bintray.com/capgeminiuk/maven/"
+        }
+    }
+    dependencies {
+        //Check for the latest version here: http://plugins.gradle.org/plugin/com.jfrog.artifactory
+        classpath("net.researchgate:gradle-release:2.3.5")
+    }
+}
 
 repositories {
     mavenLocal()
     mavenCentral()
+    maven {
+        url "https://plugins.gradle.org/m2/"
+    }
+    maven {
+        url "http://dl.bintray.com/capgeminiuk/maven/"
+    }
+
 }
 
 dependencies {
     compile     group: 'org.apache.httpcomponents', name: 'httpclient',            version: '4.3.3'
     compile     group: 'com.netflix.hystrix',       name: 'hystrix-core',          version: '1.3.16'
     compile     group: 'org.slf4j',                 name: 'slf4j-api',             version: '1.7.7'
+    compile     group: 'com.fasterxml.jackson.core',                 name: 'jackson-databind',             version: '2.7.3'
     compile     group: 'com.capgemini',             name: 'camel-exceptions-rest', version: '0.9.0'
-
 
     testCompile group: 'junit',                     name: 'junit',            version: '4.11'
     testCompile group: 'org.mockito',               name: 'mockito-all',      version: '1.9.5'

--- a/src/main/java/com/capgemini/camel/rest/client/constants/ErrorType.java
+++ b/src/main/java/com/capgemini/camel/rest/client/constants/ErrorType.java
@@ -1,0 +1,11 @@
+package com.capgemini.camel.rest.client.constants;
+
+/**
+ * Enum for types of errors
+ *
+ * @author Gayathri Thiyagarajan
+ */
+public enum ErrorType {
+    FATAL,
+    WARNING
+}

--- a/src/main/java/com/capgemini/camel/rest/client/model/RestClientErrorResponse.java
+++ b/src/main/java/com/capgemini/camel/rest/client/model/RestClientErrorResponse.java
@@ -1,0 +1,55 @@
+package com.capgemini.camel.rest.client.model;
+
+import com.capgemini.camel.rest.client.constants.ErrorType;
+
+/**
+ * This class models an error response returned by a REST call
+ *
+ * @author Gayathri Thiyagarajan
+ */
+public class RestClientErrorResponse {
+
+    private ErrorType errorType;
+    private String code;
+    private String message;
+
+    public RestClientErrorResponse() {
+    }
+
+    public RestClientErrorResponse(String code, String message) {
+        this.code = code;
+        this.message = message;
+    }
+
+    public ErrorType getErrorType() {
+        return errorType;
+    }
+
+    public void setErrorType(ErrorType errorType) {
+        this.errorType = errorType;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public void setCode(String code) {
+        this.code = code;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    @Override public String toString() {
+        return "RestClientErrorResponse{" +
+                "errorType=" + errorType +
+                ", code='" + code + '\'' +
+                ", message='" + message + '\'' +
+                '}';
+    }
+}


### PR DESCRIPTION
At present, RestClient can only handle successful response as JSON string from the server. There is no way of returning an error response in the form of JSON with an error code and message. This fix will enable us to return an error response back to the client.
